### PR TITLE
test: Assert last emitted value in stateIn flow test

### DIFF
--- a/app/src/test/java/com/droidos/thelan/NewsViewModelTest.kt
+++ b/app/src/test/java/com/droidos/thelan/NewsViewModelTest.kt
@@ -124,7 +124,7 @@ class NewsViewModelTest {
         val flow = flowOf(1, 2, 3).map { it * 10 }.stateIn(this)
 
         flow.test {
-            assertEquals(10, awaitItem())
+            assertEquals(30, awaitItem())
         }
 
     }


### PR DESCRIPTION
This commit updates the assertion in a test case for a StateFlow created using `stateIn`.

Instead of asserting the first emitted value (`10`), it now asserts the last emitted value (`30`). This ensures the test verifies the final state of the flow after all emissions.